### PR TITLE
HttpJsonCloudPlugin attempts to unregister services it correctly ignores to register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 .gradle/
 build/
 /gradle*
+
+### Eclipse/STS ###
+*.classpath
+*.factorypath
+*.project
+*.settings
+bin/

--- a/kalix-core-plugins/src/main/java/se/arkalix/core/plugin/HttpJsonCloudPlugin.java
+++ b/kalix-core-plugins/src/main/java/se/arkalix/core/plugin/HttpJsonCloudPlugin.java
@@ -211,6 +211,14 @@ public class HttpJsonCloudPlugin implements Plugin {
 
         @Override
         public void onServiceDismissed(final ServiceDescription service) {
+            if (!serviceRegistrationPredicate.test(service)) {
+                if (logger.isInfoEnabled()) {
+                    logger.info("HTTP/JSON cloud ignoring to unregister \"{}\" " +
+                        "provided by \"{}\"; the service failed to pass the " +
+                        "service registration predicate ", service.name(), system.name());
+                }
+                return;
+            }
             if (logger.isInfoEnabled()) {
                 logger.info("HTTP/JSON cloud plugin unregistering the \"{}\"" +
                     "service provided by the \"{}\" system ...", service.name(), system.name());


### PR DESCRIPTION
Hello,

After the update of Kalix library to version 0.4.7, the ArSystem#shutdown() method worked without problems in itself. However when a system attaches the HttpJsonCloudPlugin and shutdown() is call, the plugin will try to unregister from the Service Registry all the services the system provides, including does not registered in the first place if a serviceRegistrationPredicate is used. I attach the [logs](https://github.com/arrowhead-f/arrowhead-kalix/files/5348792/Shutdown.unregister.log.txt). 

Therefore in the first commit I added the same test as in the HttpJsonCloudPlugin#onServiceProvided() for it to behave equally.

Second commit was just for convenience, in case anyone uses Eclipse IDE to import the projects.

Regards,
Jaime
